### PR TITLE
Fix wrong date in episode posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10643,6 +10643,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -10677,15 +10686,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/components/Episode/index.js
+++ b/src/components/Episode/index.js
@@ -1,18 +1,8 @@
 import React from 'react';
-import moment from 'moment';
+
+import { getNormalizedDateString } from 'utils/dateUtils';
 
 import styles from './styles.css';
-
-const getNormalizedDateString = dateString => {
-  const paddedString = i => (i < 10 ? `0${i}` : `${i}`);
-
-  const date = moment(dateString);
-  const year = date.year();
-  const month = date.month() + 1;
-  const day = date.date();
-
-  return `${paddedString(day)}.${paddedString(month)}.${year}`;
-};
 
 const Episode = props => {
   if (props.digasBroadcastId === 0) {
@@ -35,7 +25,7 @@ const Episode = props => {
       </div>
       <div className={styles.meta}>
         <div className={styles.title}>
-          {props.showName} {getNormalizedDateString(props.createdAt)}
+          {props.showName} {getNormalizedDateString(props.publishAt)}
         </div>
         <div className={styles.lead}>{props.lead}</div>
       </div>
@@ -49,6 +39,7 @@ Episode.propTypes = {
   title: React.PropTypes.string,
   showName: React.PropTypes.string,
   createdAt: React.PropTypes.string,
+  publishAt: React.PropTypes.string.isRequired,
   lead: React.PropTypes.string,
   podcastUrl: React.PropTypes.string,
   playOnDemand: React.PropTypes.func,

--- a/src/components/Show/index.js
+++ b/src/components/Show/index.js
@@ -1,9 +1,3 @@
-/*
- *
- * Show
- *
- */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -27,7 +21,6 @@ import PostPreview from 'components/PostPreview';
 import ShowDetailHeader from 'components/ShowDetailHeader';
 
 export class Show extends React.Component {
-  // eslint-disable-line react/prefer-stateless-function
   componentWillMount() {
     this.props.loadShow(this.props.match.params.slug);
   }
@@ -42,13 +35,13 @@ export class Show extends React.Component {
     }
     const episodes = this.props.episodes.map(e => ({
       ...e,
-      date: e.createdAt,
+      date: e.publishAt,
       episode: true,
     }));
 
     const posts = this.props.posts.map(p => ({
       ...p,
-      date: p.createdAt,
+      date: p.publishAt,
       episode: false,
     }));
 

--- a/src/utils/dataFormatters.js
+++ b/src/utils/dataFormatters.js
@@ -18,9 +18,18 @@ export const episodeFormat = ({ id, showName, createdAt, lead }) => ({
   lead,
 });
 
-export const postFormat = ({ id, image, title, slug, lead, content }) => ({
+export const postFormat = ({
+  id,
+  image,
+  publishAt,
+  title,
+  slug,
+  lead,
+  content,
+}) => ({
   id,
   coverPhotoUrl: `${MEDIA_URL}${image}`,
+  publishAt,
   title,
   slug,
   lead,

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,12 @@
+import moment from 'moment';
+
+export const getNormalizedDateString = dateString => {
+  const paddedString = i => (i < 10 ? `0${i}` : `${i}`);
+
+  const date = moment(dateString);
+  const year = date.year();
+  const month = date.month() + 1;
+  const day = date.date();
+
+  return `${paddedString(day)}.${paddedString(month)}.${year}`;
+};

--- a/src/utils/tests/dateUtils.test.js
+++ b/src/utils/tests/dateUtils.test.js
@@ -1,0 +1,10 @@
+import { getNormalizedDateString } from '../dateUtils';
+
+describe('dateUtils', () => {
+  describe('getNormalizedDateString', () => {
+    it('should return a correctly formatted date String ', () => {
+      const originalDateString = '2012-02-23 00:00:00+00:00';
+      expect(getNormalizedDateString(originalDateString)).toEqual('23.02.2012');
+    });
+  });
+});


### PR DESCRIPTION
The `publishAt` field was forgotten in the dataTransformer, and thus the posts and episodes were not sorted correctly on a Show page. Model is now updated to use the `publishAt` field for sorting episodes/posts and as header text in episodes.