### PR TITLE
Custom episode titles

### DIFF
--- a/src/components/Episode/index.js
+++ b/src/components/Episode/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getNormalizedDateString } from 'utils/dateUtils';
-
 import styles from './styles.css';
 
 const Episode = props => {
@@ -25,9 +23,7 @@ const Episode = props => {
         <div className={styles.playButtonInner} />
       </div>
       <div className={styles.meta}>
-        <div className={styles.title}>
-          {props.showName} {getNormalizedDateString(props.publishAt)}
-        </div>
+        <div className={styles.title}>{props.title}</div>
         <div className={styles.lead}>{props.lead}</div>
       </div>
     </button>
@@ -38,11 +34,7 @@ Episode.propTypes = {
   digasBroadcastId: PropTypes.number,
   id: PropTypes.number,
   title: PropTypes.string,
-  showName: PropTypes.string,
-  createdAt: PropTypes.string,
-  publishAt: PropTypes.string.isRequired,
   lead: PropTypes.string,
-  podcastUrl: PropTypes.string,
   playOnDemand: PropTypes.func,
 };
 

--- a/src/components/Episode/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Episode/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Episode /> renders correctly 1`] = `
+<button
+  className="episode"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+>
+  <div
+    className="playButton"
+  >
+    <div
+      className="playButtonInner"
+    />
+  </div>
+  <div
+    className="meta"
+  >
+    <div
+      className="title"
+    >
+      Episode title
+    </div>
+    <div
+      className="lead"
+    >
+      Episode lead
+    </div>
+  </div>
+</button>
+`;
+
+exports[`<Episode /> should return null on invalid digasBroadcastId 1`] = `""`;

--- a/src/components/Episode/tests/index.test.js
+++ b/src/components/Episode/tests/index.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import Episode from '../';
+
+describe('<Episode />', () => {
+  it('renders correctly', () => {
+    const mockProps = {
+      digasBroadcastId: 123,
+      id: 123,
+      title: 'Episode title',
+      lead: 'Episode lead',
+      playOnDemand: jest.fn(),
+    };
+    const tree = shallow(<Episode {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should return null on invalid digasBroadcastId', () => {
+    const mockProps = {
+      digasBroadcastId: 0,
+    };
+    const tree = shallow(<Episode {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+
+    const nullEpisode = Episode(mockProps);
+    expect(nullEpisode).toBeNull();
+  });
+
+  it('calls playOnDemand when clicked', () => {
+    const mockProps = {
+      digasBroadcastId: 123,
+      id: 123,
+      title: 'Episode title',
+      lead: 'Episode lead',
+      playOnDemand: jest.fn(),
+    };
+    const tree = mount(<Episode {...mockProps} />);
+    tree.find('.episode').simulate('click');
+    expect(mockProps.playOnDemand).toBeCalled();
+  });
+
+  it('calls playOnDemand on keyPress', () => {
+    const mockProps = {
+      digasBroadcastId: 123,
+      id: 123,
+      title: 'Episode title',
+      lead: 'Episode lead',
+      playOnDemand: jest.fn(),
+    };
+    const tree = mount(<Episode {...mockProps} />);
+    tree.find('.episode').simulate('keypress');
+    expect(mockProps.playOnDemand).toBeCalled();
+  });
+});

--- a/src/components/Show/sagas.js
+++ b/src/components/Show/sagas.js
@@ -22,6 +22,7 @@ export function* loadShow(slug) {
       archived,
       episodes {
         id,
+        title,
         lead,
         createdAt,
       },

--- a/src/utils/dataFormatters.js
+++ b/src/utils/dataFormatters.js
@@ -11,8 +11,9 @@ export const showFormat = ({ id, name, image, lead, slug, archived }) => ({
   archived,
 });
 
-export const episodeFormat = ({ id, showName, createdAt, lead }) => ({
+export const episodeFormat = ({ id, title, showName, createdAt, lead }) => ({
   id,
+  title,
   showName,
   publishAt: createdAt,
   lead,


### PR DESCRIPTION
BLOCKED BY: https://github.com/Studentmediene/revolt-backend/pull/10
This PR makes the Episode component use the `title` field from the Episode model in GraphQL. GraphQL is responsible for returning the correct `title` value, based on a new field `use_title` in the database model.