### PR TITLE
Display categories

### DIFF
--- a/src/components/FrontPage/sagas.js
+++ b/src/components/FrontPage/sagas.js
@@ -13,7 +13,12 @@ export function* loadFrontPageArticles() {
       slug,
       image,
       lead,
-      publishAt
+      publishAt,
+      categories {
+        name,
+        textColor,
+        backgroundColor
+      }
     }
   }`;
   try {

--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -20,11 +20,29 @@ export class Post extends React.Component {
     }
     const time = getNormalizedDateString(this.props.post.publishAt);
 
+    let categories;
+    if (this.props.post.categories && this.props.post.categories.length > 0) {
+      categories = this.props.post.categories.map((category, index) => {
+        if (index === this.props.post.categories.length - 1) {
+          return <span key={category.name}>{category.name}</span>;
+        } else {
+          return <span key={category.name}>{category.name}, </span>;
+        }
+      });
+      categories = (
+        <div>
+          <span>Kategorier: </span>
+          {categories}
+        </div>
+      );
+    }
+
     return (
       <div className={styles.post}>
         <h1 className={styles.title}>{this.props.post.title}</h1>
         <div className={styles.meta}>
-          <span className={styles.createdAt}>{time}</span>
+          {categories}
+          <div className={styles.createdAt}>{time}</div>
         </div>
         <p
           className={styles.body}

--- a/src/components/Post/sagas.js
+++ b/src/components/Post/sagas.js
@@ -18,6 +18,11 @@ export function* loadPost(slug) {
       show{
         name,
         slug
+      },
+      categories{
+        name,
+        textColor,
+        backgroundColor
       }
     }
   }`;

--- a/src/components/PostPreview/index.js
+++ b/src/components/PostPreview/index.js
@@ -4,27 +4,48 @@ import { Link } from 'react-router-dom';
 
 import styles from './styles.css';
 
-const PostPreview = props => (
-  <div className={styles.postPreview}>
-    <Link className={styles.imageLink} to={`/post/${props.slug}`}>
-      <img
-        className={styles.image}
-        src={props.coverPhotoUrl}
-        alt={props.title}
-      />
-    </Link>
-    <Link className={styles.titleLink} to={`/post/${props.slug}`}>
-      <h2 className={styles.title}>{props.title}</h2>
-    </Link>
-    <p className={styles.lead}>{props.lead}</p>
-  </div>
-);
+const PostPreview = props => {
+  let categories;
+  if (props.categories && props.categories.length > 0) {
+    categories = props.categories.map((category, index) => (
+      <div
+        key={category.name}
+        className={styles.category}
+        style={{
+          marginTop: `-${(index + 1) * 2}em`,
+          backgroundColor: `${category.backgroundColor}`,
+          color: `${category.textColor}`,
+        }}
+      >
+        {category.name}
+      </div>
+    ));
+  }
+
+  return (
+    <div className={styles.postPreview}>
+      <Link className={styles.imageLink} to={`/post/${props.slug}`}>
+        <img
+          className={styles.image}
+          src={props.coverPhotoUrl}
+          alt={props.title}
+        />
+        {categories}
+      </Link>
+      <Link className={styles.titleLink} to={`/post/${props.slug}`}>
+        <h2 className={styles.title}>{props.title}</h2>
+      </Link>
+      <p className={styles.lead}>{props.lead}</p>
+    </div>
+  );
+};
 
 PostPreview.propTypes = {
   title: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   lead: PropTypes.string.isRequired,
   coverPhotoUrl: PropTypes.string,
+  categories: PropTypes.array,
 };
 
 export default PostPreview;

--- a/src/components/PostPreview/styles.css
+++ b/src/components/PostPreview/styles.css
@@ -26,3 +26,10 @@
 .lead {
   margin-top: 0;
 }
+
+.category {
+  position: absolute;
+  margin-left: -0.5em;
+  padding: 0.1em 0.5em;
+  border-radius: 0.3em;
+}

--- a/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
+++ b/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PostPreview /> renders correctly with categories 1`] = `
+<div
+  className="postPreview"
+>
+  <Link
+    className="imageLink"
+    replace={false}
+    to="/post/slug"
+  >
+    <img
+      alt="title"
+      className="image"
+    />
+    <div
+      className="category"
+      key="categoryName1"
+      style={
+        Object {
+          "backgroundColor": "#FFFFFF",
+          "color": "#000000",
+          "marginTop": "-2em",
+        }
+      }
+    >
+      categoryName1
+    </div>
+    <div
+      className="category"
+      key="categoryName1"
+      style={
+        Object {
+          "backgroundColor": "#FFFFFF",
+          "color": "#000000",
+          "marginTop": "-4em",
+        }
+      }
+    >
+      categoryName1
+    </div>
+  </Link>
+  <Link
+    className="titleLink"
+    replace={false}
+    to="/post/slug"
+  >
+    <h2
+      className="title"
+    >
+      title
+    </h2>
+  </Link>
+  <p
+    className="lead"
+  >
+    Lead
+  </p>
+</div>
+`;
+
+exports[`<PostPreview /> renders correctly without categories 1`] = `
+<div
+  className="postPreview"
+>
+  <Link
+    className="imageLink"
+    replace={false}
+    to="/post/slug"
+  >
+    <img
+      alt="title"
+      className="image"
+    />
+  </Link>
+  <Link
+    className="titleLink"
+    replace={false}
+    to="/post/slug"
+  >
+    <h2
+      className="title"
+    >
+      title
+    </h2>
+  </Link>
+  <p
+    className="lead"
+  >
+    Lead
+  </p>
+</div>
+`;

--- a/src/components/PostPreview/tests/index.test.js
+++ b/src/components/PostPreview/tests/index.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PostPreview from '../';
+
+describe('<PostPreview />', () => {
+  it('renders correctly with categories', () => {
+    const mockProps = {
+      image: 'image',
+      lead: 'Lead',
+      publishAt: '2017-11-01 18:11:44+00:00',
+      slug: 'slug',
+      title: 'title',
+      categories: [
+        {
+          backgroundColor: '#FFFFFF',
+          name: 'categoryName1',
+          textColor: '#000000',
+        },
+        {
+          backgroundColor: '#FFFFFF',
+          name: 'categoryName1',
+          textColor: '#000000',
+        },
+      ],
+    };
+    const tree = shallow(<PostPreview {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly without categories', () => {
+    const mockProps = {
+      image: 'image',
+      lead: 'Lead',
+      publishAt: '2017-11-01 18:11:44+00:00',
+      slug: 'slug',
+      title: 'title',
+    };
+    const tree = shallow(<PostPreview {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/PostPreviewList/tests/__snapshots__/index.test.js.snap
+++ b/src/components/PostPreviewList/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PostPreviewList /> renders correctly with posts 1`] = `
+<div
+  className="postPreviewList"
+>
+  <div
+    className="post"
+    key="post-0"
+  >
+    <PostPreview
+      categories={
+        Array [
+          Object {
+            "backgroundColor": "#FFFFFF",
+            "name": "categoryName1",
+            "textColor": "#000000",
+          },
+          Object {
+            "backgroundColor": "#FFFFFF",
+            "name": "categoryName1",
+            "textColor": "#000000",
+          },
+        ]
+      }
+      image="image"
+      lead="Lead"
+      publishAt="2017-11-01 18:11:44+00:00"
+      slug="slug1"
+      title="post1"
+    />
+  </div>
+  <div
+    className="post"
+    key="post-1"
+  >
+    <PostPreview
+      categories={Array []}
+      image="image"
+      lead="Lead"
+      publishAt="2017-11-01 18:11:44+00:01"
+      slug="slug2"
+      title="post2"
+    />
+  </div>
+</div>
+`;
+
+exports[`<PostPreviewList /> renders correctly without posts 1`] = `
+<div
+  className="postPreviewList"
+/>
+`;

--- a/src/components/PostPreviewList/tests/index.test.js
+++ b/src/components/PostPreviewList/tests/index.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PostPreviewList from '../';
+
+describe('<PostPreviewList />', () => {
+  it('renders correctly with posts', () => {
+    const mockProps = {
+      posts: [
+        {
+          image: 'image',
+          lead: 'Lead',
+          publishAt: '2017-11-01 18:11:44+00:00',
+          slug: 'slug1',
+          title: 'post1',
+          categories: [
+            {
+              backgroundColor: '#FFFFFF',
+              name: 'categoryName1',
+              textColor: '#000000',
+            },
+            {
+              backgroundColor: '#FFFFFF',
+              name: 'categoryName1',
+              textColor: '#000000',
+            },
+          ],
+        },
+        {
+          image: 'image',
+          lead: 'Lead',
+          publishAt: '2017-11-01 18:11:44+00:01',
+          slug: 'slug2',
+          title: 'post2',
+          categories: [],
+        },
+      ],
+    };
+    const tree = shallow(<PostPreviewList {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+  it('renders correctly without posts', () => {
+    const mockProps = {
+      posts: [],
+    };
+    const tree = shallow(<PostPreviewList {...mockProps} />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/utils/dataFormatters.js
+++ b/src/utils/dataFormatters.js
@@ -36,6 +36,7 @@ export const postFormat = ({
   slug,
   lead,
   content,
+  categories,
 }) => ({
   id,
   coverPhotoUrl: `${MEDIA_URL}${image}`,
@@ -44,4 +45,5 @@ export const postFormat = ({
   slug,
   lead,
   content,
+  categories,
 });


### PR DESCRIPTION
BLOCKED BY: https://github.com/Studentmediene/revolt-backend/pull/11

Categories are now displayed as overlays on images for posts on the frontpage. Also displayed as a list on the detailed page for each post.