### PR TITLE
Make embedded videos responsive

### DIFF
--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -7,6 +7,8 @@ import { withRouter } from 'react-router-dom';
 import { getNormalizedDateString } from 'utils/dateUtils';
 import { selectPost, selectPostLoading, selectPostError } from './selectors';
 import { loadPost } from './actions';
+
+import './summernote-video-attributes.css';
 import styles from './styles.css';
 
 export class Post extends React.Component {

--- a/src/components/Post/summernote-video-attributes.css
+++ b/src/components/Post/summernote-video-attributes.css
@@ -1,0 +1,11 @@
+:global(.embed-responsive-16by9) {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 */
+}
+
+:global(.embed-responsive-16by9 > iframe) {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
BLOCKED BY: https://github.com/Studentmediene/revolt-backend/pull/12 (No compatibility problems, but nothing will happen without the other PR)
This PR makes responsive videos from Django-Summernote render correctly on all screen sizes.

To review PR:
Use revolt-backend to create a post with a responsive video element. Check out the post with kapina-frontend.