### PR TITLE
Use cropped version of images for post

### DIFF
--- a/src/components/FrontPage/sagas.js
+++ b/src/components/FrontPage/sagas.js
@@ -11,7 +11,11 @@ export function* loadFrontPageArticles() {
       id,
       title,
       slug,
-      image,
+      croppedImages {
+        large,
+        medium,
+        small
+      },
       lead,
       publishAt,
       categories {

--- a/src/components/PostPreview/index.js
+++ b/src/components/PostPreview/index.js
@@ -31,11 +31,7 @@ const PostPreview = props => {
         <LazyLoad height={350} offset={100} once>
           <img
             className={styles.image}
-            srcSet={`
-              ${large} 1024w,
-              ${medium} 768w,
-              ${small} 300w
-            `}
+            srcSet={`${large} 1024w, ${medium} 768w, ${small} 300w`}
             src={large}
             alt={props.title}
           />

--- a/src/components/PostPreview/index.js
+++ b/src/components/PostPreview/index.js
@@ -23,13 +23,20 @@ const PostPreview = props => {
     ));
   }
 
+  const { small, medium, large } = props.croppedImages;
+
   return (
     <div className={styles.postPreview}>
       <Link className={styles.imageLink} to={`/post/${props.slug}`}>
         <LazyLoad height={350} offset={100} once>
           <img
             className={styles.image}
-            src={props.coverPhotoUrl}
+            srcSet={`
+              ${large} 1024w,
+              ${medium} 768w,
+              ${small} 300w
+            `}
+            src={large}
             alt={props.title}
           />
         </LazyLoad>
@@ -47,7 +54,11 @@ PostPreview.propTypes = {
   title: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   lead: PropTypes.string.isRequired,
-  coverPhotoUrl: PropTypes.string,
+  croppedImages: PropTypes.shape({
+    small: PropTypes.string,
+    medium: PropTypes.string,
+    large: PropTypes.string,
+  }),
   categories: PropTypes.array,
 };
 

--- a/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
+++ b/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
@@ -21,6 +21,12 @@ exports[`<PostPreview /> renders correctly with categories 1`] = `
       <img
         alt="title"
         className="image"
+        src="large_image"
+        srcSet="
+                    large_image 1024w,
+                    medium_image 768w,
+                    small_image 300w
+                  "
       />
     </LazyLoad>
     <div
@@ -90,6 +96,12 @@ exports[`<PostPreview /> renders correctly without categories 1`] = `
       <img
         alt="title"
         className="image"
+        src="large_image"
+        srcSet="
+                    large_image 1024w,
+                    medium_image 768w,
+                    small_image 300w
+                  "
       />
     </LazyLoad>
   </Link>

--- a/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
+++ b/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
@@ -22,11 +22,7 @@ exports[`<PostPreview /> renders correctly with categories 1`] = `
         alt="title"
         className="image"
         src="large_image"
-        srcSet="
-                    large_image 1024w,
-                    medium_image 768w,
-                    small_image 300w
-                  "
+        srcSet="large_image 1024w, medium_image 768w, small_image 300w"
       />
     </LazyLoad>
     <div
@@ -97,11 +93,7 @@ exports[`<PostPreview /> renders correctly without categories 1`] = `
         alt="title"
         className="image"
         src="large_image"
-        srcSet="
-                    large_image 1024w,
-                    medium_image 768w,
-                    small_image 300w
-                  "
+        srcSet="large_image 1024w, medium_image 768w, small_image 300w"
       />
     </LazyLoad>
   </Link>

--- a/src/components/PostPreview/tests/index.test.js
+++ b/src/components/PostPreview/tests/index.test.js
@@ -6,7 +6,11 @@ import PostPreview from '../';
 describe('<PostPreview />', () => {
   it('renders correctly with categories', () => {
     const mockProps = {
-      image: 'image',
+      croppedImages: {
+        large: 'large_image',
+        medium: 'medium_image',
+        small: 'small_image',
+      },
       lead: 'Lead',
       publishAt: '2017-11-01 18:11:44+00:00',
       slug: 'slug',
@@ -30,7 +34,11 @@ describe('<PostPreview />', () => {
 
   it('renders correctly without categories', () => {
     const mockProps = {
-      image: 'image',
+      croppedImages: {
+        large: 'large_image',
+        medium: 'medium_image',
+        small: 'small_image',
+      },
       lead: 'Lead',
       publishAt: '2017-11-01 18:11:44+00:00',
       slug: 'slug',

--- a/src/components/Show/sagas.js
+++ b/src/components/Show/sagas.js
@@ -30,7 +30,11 @@ export function* loadShow(slug) {
         id,
         title,
         slug,
-        image,
+        croppedImages {
+          large,
+          medium,
+          small
+        },
         publishAt,
         lead,
         createdBy {

--- a/src/utils/dataFormatters.js
+++ b/src/utils/dataFormatters.js
@@ -1,4 +1,3 @@
-import { MEDIA_URL } from './api';
 /*
   Functions used to convert GraphQL data to a format that fits the frontend
 */
@@ -30,7 +29,7 @@ export const episodeFormat = ({ id, title, showName, publishAt, lead }) => ({
 
 export const postFormat = ({
   id,
-  image,
+  croppedImages,
   publishAt,
   title,
   slug,
@@ -40,7 +39,7 @@ export const postFormat = ({
   episodes,
 }) => ({
   id,
-  coverPhotoUrl: `${MEDIA_URL}${image}`,
+  croppedImages,
   publishAt,
   title,
   slug,


### PR DESCRIPTION
Automatically chooses the best size based on browser width using `srcset`.

Blocked by https://github.com/Studentmediene/kapina-backend/pull/15.