### PR TITLE
Fix/make sendeplan prettier

### DIFF
--- a/src/components/Sendeplan/index.js
+++ b/src/components/Sendeplan/index.js
@@ -212,7 +212,10 @@ export class Sendeplan extends React.Component {
         ) : (
           <div>
             <div className={styles.simpleTable}>
-              <button onClick={() => this.makeSendePlanWeek()}>
+              <button
+                className={styles.toggleWeek}
+                onClick={() => this.makeSendePlanWeek()}
+              >
                 Klikk her for å se program for hele uken
               </button>
               <h3> Sendeplanen for i dag: </h3>

--- a/src/components/Sendeplan/index.js
+++ b/src/components/Sendeplan/index.js
@@ -211,19 +211,21 @@ export class Sendeplan extends React.Component {
           </div>
         ) : (
           <div>
-            <button onClick={() => this.makeSendePlanWeek()}>
-              Klikk her for å se program for hele uken
-            </button>
-            <h3> Sendeplanen for i dag: </h3>
-            <table>
-              <tbody>
-                <tr>
-                  <th>Tid</th>
-                  <th>Program</th>
-                </tr>
-                {rowToday}
-              </tbody>
-            </table>
+            <div className={styles.simpleTable}>
+              <button onClick={() => this.makeSendePlanWeek()}>
+                Klikk her for å se program for hele uken
+              </button>
+              <h3> Sendeplanen for i dag: </h3>
+              <table>
+                <tbody>
+                  <tr>
+                    <th>Tid</th>
+                    <th>Program</th>
+                  </tr>
+                  {rowToday}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
       </div>

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -1,6 +1,31 @@
+.fullTable {
+  overflow: auto;
+  border-left: 1px solid #BBB;
+  border-right: 1px solid #BBB;
+}
+
+.fullTable table {
+  table-layout: fixed;
+  border-collapse: collapse;
+  font-size: 80%;
+  width: 150%;
+}
+
+.simpleTable {
+  font-size: 80%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.simpleTable table {
+  width: 25%;
+}
+
 .sendeplan td {
   border: 1px black solid;
   padding: 6px;
+  width: 20px;
 }
 
 .sendeplan th {
@@ -15,14 +40,6 @@
   text-align: center;
 }
 
-.sendeplan table {
-  font-size: 85%;
-  position: relative;
-  left: 0;
-  right: 0;
-  width: 40%;
-}
-
 .toggleWeek {
   border: 1px #222 solid;
   padding: 10px;
@@ -35,18 +52,6 @@
   cursor: pointer;
   background-color: #222;
   color: white;
-}
-
-.fullTable {
-  overflow: auto;
-  border-left: 1px solid #BBB;
-  border-right: 1px solid #BBB;
-}
-
-.simpleTable {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 @media screen and (min-width: 1997px) {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -39,3 +39,9 @@
   border-left: 1px solid #BBB;
   border-right: 1px solid #BBB;
 }
+
+.simpleTable {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -1,15 +1,14 @@
 .sendeplan td {
   border: 1px black solid;
   padding: 6px;
-  text-align: center;
 }
 
 .sendeplan th {
   border: 1px black solid;
-  padding: 3px;
-  text-align: center;
+  padding-left: 6px;
   background-color: #ECB61C;
   color: white;
+  text-align: left;
 }
 
 .sendeplan h2 {
@@ -21,7 +20,7 @@
   position: relative;
   left: 0;
   right: 0;
-  width: 55%;
+  width: 40%;
 }
 
 .toggleWeek {
@@ -44,6 +43,12 @@
   border-right: 1px solid #BBB;
 }
 
+.simpleTable {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 @media screen and (min-width: 1997px) {
   .fullTable {
     border-left: none;
@@ -55,10 +60,4 @@
   .sendeplan table {
     align-self: center;
   }
-}
-
-.simpleTable {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -24,14 +24,18 @@
   width: 55%;
 }
 
-.sendeplan button {
-  border: 1px black solid;
+.toggleWeek {
+  border: 1px #222 solid;
   padding: 10px;
   border-radius: 2px;
+  -webkit-transition-duration: 0.3s; /* Safari */
+  transition-duration: 0.3s;
 }
 
-.sendeplan button:hover {
+.toggleWeek:hover {
   cursor: pointer;
+  background-color: #222;
+  color: white;
 }
 
 .fullTable {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -8,7 +8,11 @@
   table-layout: fixed;
   border-collapse: collapse;
   font-size: 80%;
-  width: 150%;
+  width: 1100px;
+}
+
+.fullTable table tr th:nth-child(1) {
+  width: 45px;
 }
 
 .simpleTable {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -8,11 +8,31 @@
   table-layout: fixed;
   border-collapse: collapse;
   font-size: 80%;
-  width: 1100px;
+  width: 1400px;
+  margin-left: -131px;
 }
 
+.fullTable table tr td:nth-child(1),
+.fullTable table tr th:nth-child(1) {
+  position: absolute;
+  left: 0;
+  width: 45px;
+}
+
+.sendeplan table td {
+  background-color: #F5F5F5;
+}
+
+/* z-index is set to 1 due to the first columns border
+overlaps the th-border because it's set to position: absolute
+in fullTable */
 .sendeplan table tr th:nth-child(1) {
   width: 45px;
+  z-index: 1;
+}
+
+.sendeplan {
+  position: relative;
 }
 
 .simpleTable {
@@ -23,11 +43,12 @@
 }
 
 .simpleTable table {
+  table-layout: fixed;
   width: 30%;
 }
 
 .sendeplan td {
-  border: 1px black solid;
+  border: 1px #AAA solid;
   padding: 6px;
   width: 20px;
 }

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -23,7 +23,7 @@
 }
 
 .simpleTable table {
-  width: 25%;
+  width: 30%;
 }
 
 .sendeplan td {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -39,9 +39,6 @@
 }
 
 .fullTable {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   overflow: auto;
   border-left: 1px solid #BBB;
   border-right: 1px solid #BBB;
@@ -51,6 +48,12 @@
   .fullTable {
     border-left: none;
     border-right: none;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sendeplan table {
+    align-self: center;
   }
 }
 

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -39,9 +39,19 @@
 }
 
 .fullTable {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   overflow: auto;
   border-left: 1px solid #BBB;
   border-right: 1px solid #BBB;
+}
+
+@media screen and (min-width: 1997px) {
+  .fullTable {
+    border-left: none;
+    border-right: none;
+  }
 }
 
 .simpleTable {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -1,7 +1,5 @@
 .fullTable {
   overflow: auto;
-  border-left: 1px solid #BBB;
-  border-right: 1px solid #BBB;
 }
 
 .fullTable table {

--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -11,7 +11,7 @@
   width: 1100px;
 }
 
-.fullTable table tr th:nth-child(1) {
+.sendeplan table tr th:nth-child(1) {
   width: 45px;
 }
 


### PR DESCRIPTION
Minor css fixes for sendeplan, including centering the today's sendeplan, adding a hover effect on the toggle view button, adding a media rule on the large sendeplan to remove the border when overflow is not active, and also centering the sendeplan when overflow is not active as it was for some reason displaying outside the parent div.