### PR TITLE
Add plain page for articles without header and footer

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -25,16 +25,20 @@ import { playLive } from 'components/Player/actions';
 class App extends React.Component {
   static propTypes = {
     routes: PropTypes.array.isRequired,
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
   };
   render() {
+    const plain = this.props.location.pathname.startsWith('/plainpost');
     return (
       <div className={styles.container}>
-        <Header />
+        {!plain && <Header />}
         <div className={styles.content}>
           <Switch>{this.props.routes}</Switch>
         </div>
-        <Footer />
-        <Player />
+        {!plain && <Footer />}
+        {!plain && <Player />}
       </div>
     );
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,6 +107,23 @@ export default function createRoutes(store) {
       ),
     },
     {
+      path: '/plainpost/:slug',
+      name: 'plainpost',
+      component: asyncComponent(() =>
+        Promise.all([
+          System.import('components/Post/reducer'),
+          System.import('components/Post/sagas'),
+          System.import('components/Post'),
+        ])
+          .then(([reducer, sagas, component]) => {
+            injectReducer('post', reducer.default);
+            injectSagas(sagas.default);
+            return component;
+          })
+          .catch(errorLoading),
+      ),
+    },
+    {
       path: '*',
       name: 'notfound',
       component: asyncComponent(() =>


### PR DESCRIPTION
Renders a plain page without header and footer component if the url extender starts with /plainpage:slug. For iOS app.