### PR TITLE
Change sendeplan daily table width from 30% to 200px

### DIFF
--- a/src/components/Sendeplan/styles.css
+++ b/src/components/Sendeplan/styles.css
@@ -42,7 +42,7 @@ in fullTable */
 
 .simpleTable table {
   table-layout: fixed;
-  width: 30%;
+  width: 200px;
 }
 
 .sendeplan td {


### PR DESCRIPTION
Change width of the daily table in sendeplan from 30% to 200px due to 30% of the parent div caused the text width to be greater than the table width on smaller screens, leading to text floating outside the table.