### PR TITLE
Enable source maps in production

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -52,7 +52,7 @@ module.exports = require('./webpack.base.babel')({
       },
     ],
   }),
-
+  devtool: 'source-map',
   plugins: [
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
@@ -67,6 +67,7 @@ module.exports = require('./webpack.base.babel')({
 
     // Minify and optimize the JavaScript
     new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
       compress: {
         warnings: false, // ...but do not show warnings in the console (there is a lot of them)
       },


### PR DESCRIPTION
Should make it easier to debug errors in production, especially when looking at errors reported to Sentry.