### PR TITLE
Automatically update service worker if new version is detected

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -117,6 +117,10 @@ module.exports = require('./webpack.base.babel')({
       safeToUseOptionalCaches: true,
 
       AppCache: false,
+      // Allows automatic updating
+      ServiceWorker: {
+        events: true,
+      },
     }),
   ],
 });

--- a/src/index.js
+++ b/src/index.js
@@ -63,5 +63,12 @@ ReactDOM.render(
 // Install ServiceWorker and AppCache in the end since
 // it's not most important operation and if main code fails,
 // we do not want it installed
-import { install } from 'offline-plugin/runtime';
-install();
+import { install, applyUpdate } from 'offline-plugin/runtime';
+install({
+  onUpdateReady: () => {
+    applyUpdate();
+  },
+  onUpdated: () => {
+    window.location.reload();
+  },
+});


### PR DESCRIPTION
This should finally solve our cache problems. 

The page has to reload for the new service worker to start. 