### PR TITLE
Use container based Travis builds and enable cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - '8.3'
 script: npm run build
+cache:
+  directories:
+    - "node_modules"
 notifications:
   email:
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-sudo: true
-dist: xenial
 node_js:
 - '8.3'
 script: npm run build


### PR DESCRIPTION
During weekdays Travis can take forever to start the build, so this is a test to see if the container based builds start faster. 
