### PR TITLE
Fix/147 prevent duplicate posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ stats.json
 .DS_Store/
 npm-debug.log
 .idea/
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3326,7 +3326,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -6211,14 +6211,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6238,8 +6236,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6387,7 +6384,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9227,7 +9223,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {

--- a/src/components/FrontPage/LoadPostsButton/assets/arrow_down.svg
+++ b/src/components/FrontPage/LoadPostsButton/assets/arrow_down.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">
+<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<g><path d="M77.2,223.7h-0.6L10,289.8l490,486.5l490-486.5l-66.7-66.2h-0.5l0,0L500,643.4L77.2,223.7z"/></g>
+</svg>

--- a/src/components/FrontPage/LoadPostsButton/index.js
+++ b/src/components/FrontPage/LoadPostsButton/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './styles.css';
+import arrow from './assets/arrow_down.svg';
+
+const LoadPostsButton = props => (
+  <button className={styles.loadMore} onClick={props.loadPosts}>
+    Last inn flere artikler
+    <img src={arrow} alt="Arrow" className={styles.arrow} />
+  </button>
+);
+
+LoadPostsButton.propTypes = {
+  loadPosts: PropTypes.func.isRequired,
+};
+
+export default LoadPostsButton;

--- a/src/components/FrontPage/LoadPostsButton/styles.css
+++ b/src/components/FrontPage/LoadPostsButton/styles.css
@@ -1,0 +1,13 @@
+.loadMore {
+  font-size: 22px;
+  border-width: 0;
+}
+
+.loadMore:hover {
+  cursor: pointer;
+}
+
+.arrow {
+  margin-left: 6px;
+  width: 20px;
+}

--- a/src/components/FrontPage/LoadPostsButton/tests/__snapshots__/index.test.js.snap
+++ b/src/components/FrontPage/LoadPostsButton/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LoadPostsButton /> renders correctly 1`] = `
+<button
+  className="loadMore"
+  onClick={[MockFunction]}
+>
+  Last inn flere artikler
+  <img
+    alt="Arrow"
+    className="arrow"
+    src="arrow_down.svg"
+  />
+</button>
+`;

--- a/src/components/FrontPage/LoadPostsButton/tests/index.test.js
+++ b/src/components/FrontPage/LoadPostsButton/tests/index.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import LoadPostsButton from '../';
+
+describe('<LoadPostsButton />', () => {
+  const props = {
+    loadPosts: jest.fn(),
+  };
+
+  it('renders correctly', () => {
+    const tree = shallow(<LoadPostsButton {...props} />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/FrontPage/index.js
+++ b/src/components/FrontPage/index.js
@@ -15,6 +15,7 @@ import facebookLogo from './Assets/facebook.svg';
 import instagramLogo from './Assets/instagram.svg';
 
 import Loader from 'components/Loader';
+import LoadPostsButton from './LoadPostsButton';
 import PostPreviewList from 'components/PostPreviewList';
 
 export class FrontPage extends React.Component {
@@ -32,58 +33,58 @@ export class FrontPage extends React.Component {
 
   render() {
     let posts;
-    if (this.props.loading) {
-      return <Loader />;
-    } else if (this.props.error) {
+    let socialMedia;
+    let loader = (
+      <LoadPostsButton
+        loadPosts={() => this.props.loadPosts(this.props.pageNumber)}
+      />
+    );
+    if (this.props.error) {
       return <div>Kunne ikke laste inn forsiden.</div>;
-    } else if (this.props.posts !== false) {
-      // Sort the posts so that the latest posts is first
+    }
+    if (this.props.loading) {
+      loader = <Loader />;
+    }
+    if (this.props.posts !== false) {
+      // Sort the posts so that the last published posts are first
       posts = this.props.posts.sort((postA, postB) =>
         moment(postB.publishAt).diff(postA.publishAt),
       );
       posts = <PostPreviewList posts={this.props.posts} />;
-
-      return (
-        <div className={styles.frontPage}>
-          {posts}
-          <div className={styles.socialMedia}>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://www.facebook.com/radiorevolt.no/"
-            >
-              <img
-                src={facebookLogo}
-                alt="Facebook"
-                className={styles.facebookLogo}
-              />
-            </a>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://www.instagram.com/radiorevolt/"
-            >
-              <img
-                src={instagramLogo}
-                alt="Instagram"
-                className={styles.instagramLogo}
-              />
-            </a>
-          </div>
-          <div className={styles.buttonWrap}>
-            <button
-              className={styles.loadMore}
-              onClick={() => this.props.loadPosts(this.props.pageNumber)}
-            >
-              Last inn flere artikler
-            </button>
-          </div>
+      socialMedia = (
+        <div className={styles.socialMedia}>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.facebook.com/radiorevolt.no/"
+          >
+            <img
+              src={facebookLogo}
+              alt="Facebook"
+              className={styles.facebookLogo}
+            />
+          </a>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.instagram.com/radiorevolt/"
+          >
+            <img
+              src={instagramLogo}
+              alt="Instagram"
+              className={styles.instagramLogo}
+            />
+          </a>
         </div>
       );
-    } else {
-      // Render loading component before load actually starts.
-      return <Loader />;
     }
+    return (
+      <div>
+        {posts}
+        {socialMedia}
+        <div className={styles.loaderWrapper}>{loader}</div>
+      </div>
+    );
   }
 }
 

--- a/src/components/FrontPage/index.js
+++ b/src/components/FrontPage/index.js
@@ -8,6 +8,7 @@ import {
   selectFrontPagePostsLoading,
   selectFrontPagePostsError,
   selectPageNumber,
+  selectHasLoaded,
 } from './selectors';
 import { loadFrontPagePosts } from './actions';
 import styles from './styles.css';
@@ -25,10 +26,13 @@ export class FrontPage extends React.Component {
     error: PropTypes.bool.isRequired,
     loadPosts: PropTypes.func.isRequired,
     pageNumber: PropTypes.number.isRequired,
+    hasLoaded: PropTypes.bool.isRequired,
   };
 
   componentWillMount() {
-    this.props.loadPosts(this.props.pageNumber);
+    if (!this.props.hasLoaded) {
+      this.props.loadPosts(this.props.pageNumber);
+    }
   }
 
   render() {
@@ -93,6 +97,7 @@ const mapStateToProps = createStructuredSelector({
   loading: selectFrontPagePostsLoading(),
   error: selectFrontPagePostsError(),
   pageNumber: selectPageNumber(),
+  hasLoaded: selectHasLoaded(),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/components/FrontPage/reducer.js
+++ b/src/components/FrontPage/reducer.js
@@ -1,9 +1,3 @@
-/*
- *
- * FrontPage reducer
- *
- */
-
 import { fromJS } from 'immutable';
 import {
   LOAD_FRONT_PAGE_POSTS_PENDING,
@@ -16,6 +10,7 @@ const initialState = fromJS({
   error: false,
   posts: false,
   pageNumber: 1,
+  hasLoaded: false,
 });
 
 function frontPageReducer(state = initialState, action) {
@@ -27,6 +22,7 @@ function frontPageReducer(state = initialState, action) {
         .set('loading', false)
         .set('error', false)
         .set('posts', [...state.get('posts'), ...action.posts])
+        .set('hasLoaded', true)
         .set('pageNumber', state.get('pageNumber') + 1);
     case LOAD_FRONT_PAGE_POSTS_FAILED:
       return state.set('loading', false).set('error', true);

--- a/src/components/FrontPage/selectors.js
+++ b/src/components/FrontPage/selectors.js
@@ -1,17 +1,6 @@
 import { createSelector } from 'reselect';
 
-/**
- * Direct selector to the frontPage state domain
- */
 const selectFrontPageDomain = () => state => state.get('frontPage');
-
-/**
- * Other specific selectors
- */
-
-/**
- * Default selector used by FrontPage
- */
 
 const selectFrontPagePosts = () =>
   createSelector(selectFrontPageDomain(), frontPage => frontPage.get('posts'));
@@ -29,10 +18,15 @@ const selectPageNumber = () =>
     return frontPage.get('pageNumber');
   });
 
+const selectHasLoaded = () =>
+  createSelector(selectFrontPageDomain(), frontPage => {
+    return frontPage.get('hasLoaded');
+  });
+
 export {
-  selectFrontPageDomain,
   selectFrontPagePosts,
   selectFrontPagePostsLoading,
   selectFrontPagePostsError,
   selectPageNumber,
+  selectHasLoaded,
 };

--- a/src/components/FrontPage/styles.css
+++ b/src/components/FrontPage/styles.css
@@ -1,18 +1,8 @@
-.buttonWrap {
-  align-items: center;
+.loaderWrapper {
   display: flex;
+  align-items: center;
   flex-direction: column;
   width: 100%;
-}
-
-.loadMore {
-  background-color: #ECB61C;
-  border: 0;
-  padding: 10px;
-}
-
-.loadMore:hover {
-  cursor: pointer;
 }
 
 .socialMedia {

--- a/src/components/FrontPage/tests/__snapshots__/index.test.js.snap
+++ b/src/components/FrontPage/tests/__snapshots__/index.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FrontPage /> renders correctly 1`] = `
-<div
-  className="frontPage"
->
+<div>
   <PostPreviewList
     posts={Array []}
   />
@@ -34,14 +32,11 @@ exports[`<FrontPage /> renders correctly 1`] = `
     </a>
   </div>
   <div
-    className="buttonWrap"
+    className="loaderWrapper"
   >
-    <button
-      className="loadMore"
-      onClick={[Function]}
-    >
-      Last inn flere artikler
-    </button>
+    <LoadPostsButton
+      loadPosts={[Function]}
+    />
   </div>
 </div>
 `;
@@ -52,4 +47,12 @@ exports[`<FrontPage /> renders correctly on error 1`] = `
 </div>
 `;
 
-exports[`<FrontPage /> renders correctly while loading 1`] = `<Loader />`;
+exports[`<FrontPage /> renders correctly while loading 1`] = `
+<div>
+  <div
+    className="loaderWrapper"
+  >
+    <Loader />
+  </div>
+</div>
+`;

--- a/src/components/FrontPage/tests/index.test.js
+++ b/src/components/FrontPage/tests/index.test.js
@@ -11,6 +11,7 @@ describe('<FrontPage />', () => {
       error: false,
       pageNumber: 1,
       loadPosts: jest.fn(),
+      hasLoaded: false,
     };
 
     const tree = shallow(<FrontPage {...props} />);
@@ -23,6 +24,7 @@ describe('<FrontPage />', () => {
       error: false,
       pageNumber: 1,
       loadPosts: jest.fn(),
+      hasLoaded: false,
     };
 
     const tree = shallow(<FrontPage {...props} />);
@@ -35,6 +37,7 @@ describe('<FrontPage />', () => {
       error: true,
       pageNumber: 1,
       loadPosts: jest.fn(),
+      hasLoaded: false,
     };
 
     const tree = shallow(<FrontPage {...props} />);

--- a/src/components/PostPreviewList/index.js
+++ b/src/components/PostPreviewList/index.js
@@ -10,7 +10,6 @@ const PostPreviewList = props => {
       <PostPreview {...post} />
     </div>
   ));
-
   return <div className={styles.postPreviewList}>{posts}</div>;
 };
 


### PR DESCRIPTION
This PR prevents prevents the frontpage from loading duplicate posts after navigating to another component, and then back to the frontpage.