### PR TITLE
build: update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ script: npm run build
 notifications:
   email:
     on_failure: change
-  slack:
-    secure: KoGNFUnoDzwPxBV8WnXU+XoihHhNQGkspYOvgnSZha+Ta6+nFbIiHai1K/F0QddT43aElQk9ko7nL5aLO2GTQzlBvgmJIYniQznurhe0FLBttGWqj7A/PjfVuyF6MlBYk62fP0zKT/KBDAU1jr4ox00GCkbFHxHle0aeeDI+mD7xZV8ImB4fr6f9OI65WpLQrNWRPYFfEuYN0EPxq4MaBv3f8CGJtXL8+VCN2gZcqVDA4UEjHQ9QwWKhUdLxeRyD9fH5h13TxG+84UXHVtKRoYolj1uruqur0NrS+5lj+JZM1ZBmvFvYnvDbC0kYOR+T1A0lD4pr0Wnz++nlafz6MxGhn1bgcxOwJogvOv4nnZRaBVgYVRMCe1RBlu8hQvsrdsqGbXEcckdlJWeCzfvEs3yuf1UOcvA44WLsGLqicwtORXktiRjR7CpL2JnoTNV5xyzC53rfDz3jbS5QhrdLa/y047JgpC5xnAnJEj6d53mmQqY7I4BOaxLcovSqcNsqoI1LdhVCNPVYqQttcgQuCf3IDXwW7v+5OKs9Q+dYxqwxll4/g3C86rJtNZFUz8ybVc46WyK+8ddbVkFj1AD0cIVwqN7jlUEaPDKgAf67txeQeE7+05a7cWUafQxgx1153p02r9/UL98cw/OjLsS/zMS9SnqrTv+E5+8twHYwwSU=
+  webhooks: https://outlook.office.com/webhook/bba8187b-2198-46bb-adf5-dca60d4fbb1d@c845b8fa-0078-426b-8679-0da9f5eb0eed/TravisCI/a26937dbfb7948f5949f833416a1911a/1b4ab707-7048-4474-8611-7109f10acef8


### PR DESCRIPTION
Updates the Travis configuration, so that it posts updates to MS Teams instead of Slack