### PR TITLE
Scroll to top when route changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,16 +45,16 @@ const store = configureStore(initialState, history);
 
 const routes = createRoutes(store).map(route => (
   <Route path={route.path} key={route.path} exact={route.exact}>
-    <ScrollToTop>
-      <route.component />
-    </ScrollToTop>
+    <route.component />
   </Route>
 ));
 
 ReactDOM.render(
   <Provider store={store}>
     <ConnectedRouter history={history}>
-      <App routes={routes} />
+      <ScrollToTop>
+        <App routes={routes} />
+      </ScrollToTop>
     </ConnectedRouter>
   </Provider>,
   document.getElementById('app'),

--- a/src/utils/scrollToTopComponent.js
+++ b/src/utils/scrollToTopComponent.js
@@ -8,7 +8,7 @@ export class ScrollToTop extends React.Component {
     location: PropTypes.object.isRequired,
   };
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
       window.scrollTo(0, 0);
     }
   }


### PR DESCRIPTION
The webpage did not scroll to the top when navigating to a new route, due to React. This small PR makes the browser scroll to the top every time the URL/location.pathname changes. 

To test:
Make the height of your browser small, scroll a few pixels down, then click on a nacigation link in the navigation bar. The broswer should scroll to the top when changing route, but stay at your current position when navigating to the same location that you are currently in. 