### PR TITLE
fix: add check if serviceworker is supported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,11 +64,13 @@ ReactDOM.render(
 // it's not most important operation and if main code fails,
 // we do not want it installed
 import { install, applyUpdate } from 'offline-plugin/runtime';
-install({
-  onUpdateReady: () => {
-    applyUpdate();
-  },
-  onUpdated: () => {
-    window.location.reload();
-  },
-});
+if ('serviceWorker' in navigator) {
+  install({
+    onUpdateReady: () => {
+      applyUpdate();
+    },
+    onUpdated: () => {
+      window.location.reload();
+    },
+  });
+}


### PR DESCRIPTION
Failing to register a serviceworker on non-supported cleint account for about 100 errors per month in Sentry.