### PR TITLE
Improve keyboard and screen readers' UX

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -29,9 +29,9 @@ export class App extends React.Component {
     return (
       <div className={styles.container}>
         {!plain && <Header />}
-        <div className={styles.content}>
+        <main className={styles.content}>
           <Switch>{this.props.routes}</Switch>
-        </div>
+        </main>
         {!plain && <Sidebar />}
         {!plain && <Footer />}
         {!plain && <Player />}

--- a/src/components/App/styles.scss
+++ b/src/components/App/styles.scss
@@ -21,7 +21,8 @@
 
 // Ensure consistent styling of outline, since we must change it sometimes to
 // ensure good enough contrast
-a, button {
+a,
+button {
   &:focus {
     outline: 1px dotted #212121;
   }

--- a/src/components/App/styles.scss
+++ b/src/components/App/styles.scss
@@ -18,3 +18,11 @@
     max-width: $breakpoint-large;
   }
 }
+
+// Ensure consistent styling of outline, since we must change it sometimes to
+// ensure good enough contrast
+a, button {
+  &:focus {
+    outline: 1px dotted #212121;
+  }
+}

--- a/src/components/App/tests/__snapshots__/index.test.js.snap
+++ b/src/components/App/tests/__snapshots__/index.test.js.snap
@@ -5,11 +5,11 @@ exports[`<App /> renders correctly 1`] = `
   className="container"
 >
   <Header />
-  <div
+  <main
     className="content"
   >
     <Switch />
-  </div>
+  </main>
   <Sidebar />
   <Connect(Footer) />
   <Connect(Player) />
@@ -20,10 +20,10 @@ exports[`<App /> renders plainpost correctly 1`] = `
 <div
   className="container"
 >
-  <div
+  <main
     className="content"
   >
     <Switch />
-  </div>
+  </main>
 </div>
 `;

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -34,17 +34,14 @@ export class Footer extends React.Component {
     let { radioEditor, chiefEditor, musicProducer } = this.props;
 
     return (
-      <div className={styles.footer}>
+      <footer className={styles.footer}>
         <div className={styles.content}>
-          <div>
+          <p>
             Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er
-            gjengitt med tilatelse fra TONO/NCB.
-          </div>
-          <div>
+            gjengitt med tillatelse fra TONO/NCB.<br />
             Uautorisert lenking, videreføring eller kopiering er ulovlig.
-          </div>
-          <br />
-          <div className={styles.bold}>Kontakt oss</div>
+          </p>
+          <h2 className={styles.contactHeader}>Kontakt oss</h2>
           <a
             className={styles.footerLink}
             href="mailto:radioredaktor@studentmediene.no"
@@ -76,7 +73,7 @@ export class Footer extends React.Component {
           </Link>
           <p>{new Date().getFullYear()} © Radio Revolt</p>
         </div>
-      </div>
+      </footer>
     );
   }
 }

--- a/src/components/Footer/styles.scss
+++ b/src/components/Footer/styles.scss
@@ -10,6 +10,14 @@
   margin-top: 5rem;
   padding: 3rem 0;
   color: $color-text-light;
+
+
+  // Change to light color for outline, due to dark background
+  a, button {
+    &:focus {
+      outline-color: white;
+    }
+  }
 }
 
 .content {
@@ -24,10 +32,10 @@
 .footerLink {
   color: $color-text-light;
   text-decoration: none;
-}
 
-.footerLink:hover {
-  text-decoration: underline;
+  &:hover, &:focus {
+    text-decoration: underline;
+  }
 }
 
 .socialMediaLinks {

--- a/src/components/Footer/styles.scss
+++ b/src/components/Footer/styles.scss
@@ -11,9 +11,9 @@
   padding: 3rem 0;
   color: $color-text-light;
 
-
   // Change to light color for outline, due to dark background
-  a, button {
+  a,
+  button {
     &:focus {
       outline-color: white;
     }
@@ -33,7 +33,8 @@
   color: $color-text-light;
   text-decoration: none;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 }
@@ -42,8 +43,9 @@
   display: block;
 }
 
-.bold {
-  font-weight: bold;
+.contactHeader {
+  font-size: inherit;
+  margin-bottom: 0;
 }
 
 @media screen and (min-width: $social-media-button-breakpoint) {

--- a/src/components/Footer/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Footer/tests/__snapshots__/index.test.js.snap
@@ -1,24 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Footer /> renders correctly 1`] = `
-<div
+<footer
   className="footer"
 >
   <div
     className="content"
   >
-    <div>
-      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tilatelse fra TONO/NCB.
-    </div>
-    <div>
+    <p>
+      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tillatelse fra TONO/NCB.
+      <br />
       Uautorisert lenking, videreføring eller kopiering er ulovlig.
-    </div>
-    <br />
-    <div
-      className="bold"
+    </p>
+    <h2
+      className="contactHeader"
     >
       Kontakt oss
-    </div>
+    </h2>
     <a
       className="footerLink"
       href="mailto:radioredaktor@studentmediene.no"
@@ -66,28 +64,26 @@ exports[`<Footer /> renders correctly 1`] = `
        © Radio Revolt
     </p>
   </div>
-</div>
+</footer>
 `;
 
 exports[`<Footer /> renders correctly on error 1`] = `
-<div
+<footer
   className="footer"
 >
   <div
     className="content"
   >
-    <div>
-      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tilatelse fra TONO/NCB.
-    </div>
-    <div>
+    <p>
+      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tillatelse fra TONO/NCB.
+      <br />
       Uautorisert lenking, videreføring eller kopiering er ulovlig.
-    </div>
-    <br />
-    <div
-      className="bold"
+    </p>
+    <h2
+      className="contactHeader"
     >
       Kontakt oss
-    </div>
+    </h2>
     <a
       className="footerLink"
       href="mailto:radioredaktor@studentmediene.no"
@@ -135,28 +131,26 @@ exports[`<Footer /> renders correctly on error 1`] = `
        © Radio Revolt
     </p>
   </div>
-</div>
+</footer>
 `;
 
 exports[`<Footer /> renders correctly while loading 1`] = `
-<div
+<footer
   className="footer"
 >
   <div
     className="content"
   >
-    <div>
-      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tilatelse fra TONO/NCB.
-    </div>
-    <div>
+    <p>
+      Denne tjenesten tilbys av Studentmediene i Trondheim AS. Musikken er gjengitt med tillatelse fra TONO/NCB.
+      <br />
       Uautorisert lenking, videreføring eller kopiering er ulovlig.
-    </div>
-    <br />
-    <div
-      className="bold"
+    </p>
+    <h2
+      className="contactHeader"
     >
       Kontakt oss
-    </div>
+    </h2>
     <a
       className="footerLink"
       href="mailto:radioredaktor@studentmediene.no"
@@ -204,5 +198,5 @@ exports[`<Footer /> renders correctly while loading 1`] = `
        © Radio Revolt
     </p>
   </div>
-</div>
+</footer>
 `;

--- a/src/components/FrontPage/components/HighlightedPosts/styles.scss
+++ b/src/components/FrontPage/components/HighlightedPosts/styles.scss
@@ -14,7 +14,8 @@
   background-color: $color-radiorevolt-lightgrey;
 
   // Lighter outline color, for contrast
-  a, button {
+  a,
+  button {
     &:focus {
       outline-color: white;
     }

--- a/src/components/FrontPage/components/HighlightedPosts/styles.scss
+++ b/src/components/FrontPage/components/HighlightedPosts/styles.scss
@@ -12,6 +12,13 @@
 
   color: $color-text-light;
   background-color: $color-radiorevolt-lightgrey;
+
+  // Lighter outline color, for contrast
+  a, button {
+    &:focus {
+      outline-color: white;
+    }
+  }
 }
 
 .title {

--- a/src/components/FrontPage/components/HighlightedPosts/tests/__snapshots__/index.test.js.snap
+++ b/src/components/FrontPage/components/HighlightedPosts/tests/__snapshots__/index.test.js.snap
@@ -20,6 +20,7 @@ exports[`<HighlightedPosts /> renders correctly 1`] = `
     >
       <ImageLink
         imageDescription="title1"
+        imageProps={Object {}}
         images={
           Object {
             "large": "/large1.jpg",
@@ -42,6 +43,7 @@ exports[`<HighlightedPosts /> renders correctly 1`] = `
     >
       <ImageLink
         imageDescription="title2"
+        imageProps={Object {}}
         images={
           Object {
             "large": "/large2.jpg",

--- a/src/components/FrontPage/components/LoadPostsButton/index.js
+++ b/src/components/FrontPage/components/LoadPostsButton/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import styles from './styles.css';
+import styles from './styles.scss';
 import arrow from './assets/arrow_down.svg';
 
 const LoadPostsButton = props => (
   <button className={styles.loadMore} onClick={props.loadPosts}>
     Last inn flere artikler
-    <img src={arrow} alt="Arrow" className={styles.arrow} />
+    <img src={arrow} alt="" className={styles.arrow} />
   </button>
 );
 

--- a/src/components/FrontPage/components/LoadPostsButton/styles.scss
+++ b/src/components/FrontPage/components/LoadPostsButton/styles.scss
@@ -2,9 +2,6 @@
   font-size: 22px;
   margin-top: 1em;
   border-width: 0;
-}
-
-.loadMore:hover {
   cursor: pointer;
 }
 

--- a/src/components/FrontPage/components/LoadPostsButton/tests/__snapshots__/index.test.js.snap
+++ b/src/components/FrontPage/components/LoadPostsButton/tests/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ exports[`<LoadPostsButton /> renders correctly 1`] = `
 >
   Last inn flere artikler
   <img
-    alt="Arrow"
+    alt=""
     className="arrow"
     src="arrow_down.svg"
   />

--- a/src/components/Header/HamburgerMenu/index.js
+++ b/src/components/Header/HamburgerMenu/index.js
@@ -43,11 +43,17 @@ export class HamburgerMenu extends React.Component {
       <button className={styles.container} onClick={this.toggleMenu}>
         <img src={hamburgerIcon} className={styles.hamburgerIcon} />
         <div className={styles.hamburgerText}>Meny</div>
-        <div className={classNames({
-          [styles.overlay]: true,
-          [styles.active]: this.state.isOpen,
-        })}></div>
-        <NavDrawer links={navLinks} open={this.state.isOpen} onNavigation={this.toggleMenu}/>
+        <div
+          className={classNames({
+            [styles.overlay]: true,
+            [styles.active]: this.state.isOpen,
+          })}
+        />
+        <NavDrawer
+          links={navLinks}
+          open={this.state.isOpen}
+          onNavigation={this.toggleMenu}
+        />
       </button>
     );
   }

--- a/src/components/Header/HamburgerMenu/index.js
+++ b/src/components/Header/HamburgerMenu/index.js
@@ -40,7 +40,7 @@ export class HamburgerMenu extends React.Component {
 
   render() {
     return (
-      <div className={styles.container} onClick={this.toggleMenu}>
+      <button className={styles.container} onClick={this.toggleMenu}>
         <img src={hamburgerIcon} className={styles.hamburgerIcon} />
         <div className={styles.hamburgerText}>Meny</div>
         <div className={classNames({
@@ -48,7 +48,7 @@ export class HamburgerMenu extends React.Component {
           [styles.active]: this.state.isOpen,
         })}></div>
         <NavDrawer links={navLinks} open={this.state.isOpen} onNavigation={this.toggleMenu}/>
-      </div>
+      </button>
     );
   }
 }

--- a/src/components/Header/HamburgerMenu/styles.scss
+++ b/src/components/Header/HamburgerMenu/styles.scss
@@ -10,6 +10,7 @@
 
   padding: 10px;
   margin-left: 20px;
+  border-style: none;
   border-radius: 10px;
   background-color: $color-radiorevolt-darkgrey;
 }

--- a/src/components/Header/HamburgerMenu/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Header/HamburgerMenu/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<HamburgerMenu /> renders correctly 1`] = `
-<div
+<button
   className="container"
   onClick={[Function]}
 >
@@ -37,5 +37,5 @@ exports[`<HamburgerMenu /> renders correctly 1`] = `
     onNavigation={[Function]}
     open={false}
   />
-</div>
+</button>
 `;

--- a/src/components/Header/HeaderPlayButton/index.js
+++ b/src/components/Header/HeaderPlayButton/index.js
@@ -33,7 +33,7 @@ export class HeaderPlayButton extends React.Component {
     }
 
     return (
-      <div className={styles.container} onClick={buttonClicked}>
+      <button className={styles.container} onClick={buttonClicked}>
         <PlayPauseButton
           paused={!isCurrentlyLive}
         />
@@ -41,7 +41,7 @@ export class HeaderPlayButton extends React.Component {
           <div className={styles.largeText}>Lytt direkte!</div>
           <div className={styles.smallText}>{this.props.nowPlaying}</div>
         </div>
-      </div>
+      </button>
     );
   }
 }

--- a/src/components/Header/HeaderPlayButton/index.js
+++ b/src/components/Header/HeaderPlayButton/index.js
@@ -16,7 +16,6 @@ export class HeaderPlayButton extends React.Component {
   };
 
   render() {
-
     let isCurrentlyLive = false;
 
     if (!this.props.paused && this.props.isLive) {
@@ -30,13 +29,11 @@ export class HeaderPlayButton extends React.Component {
       } else {
         this.props.playLive();
       }
-    }
+    };
 
     return (
       <button className={styles.container} onClick={buttonClicked}>
-        <PlayPauseButton
-          paused={!isCurrentlyLive}
-        />
+        <PlayPauseButton paused={!isCurrentlyLive} />
         <div className={styles.buttonText}>
           <div className={styles.largeText}>Lytt direkte!</div>
           <div className={styles.smallText}>{this.props.nowPlaying}</div>

--- a/src/components/Header/HeaderPlayButton/styles.scss
+++ b/src/components/Header/HeaderPlayButton/styles.scss
@@ -40,6 +40,7 @@
   .buttonText {
     display: flex;
   }
+
   .largeText {
     display: block;
   }
@@ -50,6 +51,7 @@
     margin-right: 0;
     background-color: $color-radiorevolt-lightgrey;
   }
+
   .smallText {
     display: block;
   }

--- a/src/components/Header/HeaderPlayButton/styles.scss
+++ b/src/components/Header/HeaderPlayButton/styles.scss
@@ -1,6 +1,10 @@
 @import 'variables.scss';
 
 .container {
+  // Reset browser button styles
+  border: none;
+
+  // Our own styles
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/src/components/Header/HeaderPlayButton/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Header/HeaderPlayButton/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<HeaderPlayButton /> renders correctly 1`] = `
-<div
+<button
   className="container"
   onClick={[Function]}
 >
@@ -22,5 +22,5 @@ exports[`<HeaderPlayButton /> renders correctly 1`] = `
        Current show
     </div>
   </div>
-</div>
+</button>
 `;

--- a/src/components/Header/NavDrawer/index.js
+++ b/src/components/Header/NavDrawer/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { withRouter  } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 
 import logo from 'components/Header/Logo/RR_logo.png';
 import styles from './styles.scss';
@@ -13,8 +13,8 @@ export class NavDrawer extends React.Component {
     onNavigation: PropTypes.func.isRequired,
   };
 
-  constructor(props){
-    super(props)
+  constructor(props) {
+    super(props);
 
     this.navigate = this.navigate.bind(this);
     this.preventInteraction = this.preventInteraction.bind(this);
@@ -32,30 +32,35 @@ export class NavDrawer extends React.Component {
   }
 
   render() {
-    const navbarComponents = links => links.map(link => (
-      <a
-        href={link.path}
-        key={link.path}
-        className={styles.navItem}
-        onClick={(e) => this.navigate(e, link.path)}
-      >
-        {link.title}
-      </a>
-    ));
+    const navbarComponents = links =>
+      links.map(link => (
+        <a
+          href={link.path}
+          key={link.path}
+          className={styles.navItem}
+          onClick={e => this.navigate(e, link.path)}
+        >
+          {link.title}
+        </a>
+      ));
 
     return (
-      <div className={
-        classNames({
+      <div
+        className={classNames({
           [styles.navDrawer]: true,
           [styles.open]: this.props.open,
         })}
-        onClick={this.preventInteraction}>
-        <a href="/" className={styles.logoRow} onClick={(e) => this.navigate(e, '/')}>
+        onClick={this.preventInteraction}
+      >
+        <a
+          href="/"
+          className={styles.logoRow}
+          onClick={e => this.navigate(e, '/')}
+        >
           <img src={logo} className={styles.logo} />
         </a>
         {navbarComponents(this.props.links)}
       </div>
-    
     );
   }
 }

--- a/src/components/Header/NavDrawer/index.js
+++ b/src/components/Header/NavDrawer/index.js
@@ -22,7 +22,9 @@ export class NavDrawer extends React.Component {
 
   navigate(e, destination) {
     this.props.onNavigation(e);
-    this.props.history.push(destination)
+    this.props.history.push(destination);
+    // Stop browser from acting on the link click
+    return false;
   }
 
   preventInteraction(e) {
@@ -31,14 +33,15 @@ export class NavDrawer extends React.Component {
 
   render() {
     const navbarComponents = links => links.map(link => (
-      <div 
+      <a
+        href={link.path}
         key={link.path}
         className={styles.navItem}
         onClick={(e) => this.navigate(e, link.path)}
       >
         {link.title}
-      </div>
-    ))
+      </a>
+    ));
 
     return (
       <div className={
@@ -47,9 +50,9 @@ export class NavDrawer extends React.Component {
           [styles.open]: this.props.open,
         })}
         onClick={this.preventInteraction}>
-        <div className={styles.logoRow}>
-          <img src={logo} className={styles.logo} onClick={(e) => this.navigate(e, '/')} />
-        </div>
+        <a href="/" className={styles.logoRow} onClick={(e) => this.navigate(e, '/')}>
+          <img src={logo} className={styles.logo} />
+        </a>
         {navbarComponents(this.props.links)}
       </div>
     

--- a/src/components/Header/NavDrawer/styles.scss
+++ b/src/components/Header/NavDrawer/styles.scss
@@ -15,7 +15,6 @@
   justify-content: flex-start;
   align-items: flex-start;
 
-
   cursor: initial;
   background-color: $color-radiorevolt-lightgrey;
   box-shadow: 2px 0 2px $color-radiorevolt-darkgrey;
@@ -23,14 +22,14 @@
 }
 
 .open {
-  max-width: 100vw;;
+  max-width: 100vw;
 }
 
 .logoRow {
   display: flex;
   flex-direction: row;
   justify-content: center;
-  
+
   width: 100%;
   padding: 10px;
 }
@@ -50,7 +49,8 @@
   text-decoration: none;
   cursor: pointer;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     background-color: $color-radiorevolt-darkgrey;
   }
 }

--- a/src/components/Header/NavDrawer/styles.scss
+++ b/src/components/Header/NavDrawer/styles.scss
@@ -46,9 +46,11 @@
   font-size: 21px;
   border-top: 1px solid $color-radiorevolt-darkgrey;
   border-bottom: 1px solid $color-radiorevolt-darkgrey;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
 
-  &:hover {
-    cursor: pointer;
+  &:hover, &:focus {
     background-color: $color-radiorevolt-darkgrey;
   }
 }

--- a/src/components/Header/NavList/styles.scss
+++ b/src/components/Header/NavList/styles.scss
@@ -15,13 +15,13 @@
   font-size: 21px;
 }
 
-.navbarItem:hover {
-  text-decoration: underline;
-}
-
 .navbarLink {
   text-decoration: none;
   color: inherit;
+
+  &:hover, &:focus {
+    text-decoration: underline;
+  }
 }
 
 @media screen and (min-width: $breakpoint-medium) {

--- a/src/components/Header/NavList/styles.scss
+++ b/src/components/Header/NavList/styles.scss
@@ -19,13 +19,14 @@
   text-decoration: none;
   color: inherit;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 }
 
 @media screen and (min-width: $breakpoint-medium) {
   .navbarItem {
-    margin: 0px 10px;
+    margin: 0 10px;
   }
 }

--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -7,13 +7,13 @@
 
   flex: 1;
   height: $header-height;
-  
 
   color: $color-text-light;
   background-color: $color-radiorevolt-lightgrey;
 
   // Change to light color for outline, due to dark background
-  a, button {
+  a,
+  button {
     &:focus {
       outline-color: white;
     }
@@ -25,7 +25,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  
+
   flex: 1;
   max-width: $breakpoint-large;
 }

--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -11,6 +11,13 @@
 
   color: $color-text-light;
   background-color: $color-radiorevolt-lightgrey;
+
+  // Change to light color for outline, due to dark background
+  a, button {
+    &:focus {
+      outline-color: white;
+    }
+  }
 }
 
 .headerContent {

--- a/src/components/Player/components/PlayPauseButton.js
+++ b/src/components/Player/components/PlayPauseButton.js
@@ -4,22 +4,36 @@ import classNames from 'classnames';
 
 import styles from './PlayPauseButton.scss';
 
-const PlayPauseButton = ({ togglePlayPause, paused }) => (
-  <button
-    className={styles.playPauseButton}
-    onClick={togglePlayPause}
-    onKeyPress={togglePlayPause}
-  >
-    <div className={styles.buttonContainer}>
-      <div className={classNames(styles.left, {
-        [styles.paused]: paused,
-      })} />
-      <div className={classNames(styles.right, {
-        [styles.paused]: paused,
-      })} />
-    </div>
-  </button>
-);
+import SrOnly from 'components/common/SrOnly';
+
+const PlayPauseButton = ({ togglePlayPause, paused }) => {
+  // Label for our screenreader friends
+  const label = paused ? 'Spill av' : 'Pause';
+
+  const contents = <div className={styles.buttonContainer}>
+    <div className={classNames(styles.left, {
+      [styles.paused]: paused,
+    })} />
+    <div className={classNames(styles.right, {
+      [styles.paused]: paused,
+    })} />
+    <SrOnly>{label}</SrOnly>
+  </div>;
+
+  // Use a <button> if we are interactive, else nothing
+  if (togglePlayPause) {
+    return (
+      <button
+        className={styles.playPauseButton}
+        onClick={togglePlayPause}
+      >
+        {contents}
+      </button>
+    );
+  } else {
+    return contents;
+  }
+};
 
 PlayPauseButton.propTypes = {
   togglePlayPause: PropTypes.func,

--- a/src/components/Player/components/PlayPauseButton.js
+++ b/src/components/Player/components/PlayPauseButton.js
@@ -10,23 +10,26 @@ const PlayPauseButton = ({ togglePlayPause, paused }) => {
   // Label for our screenreader friends
   const label = paused ? 'Spill av' : 'Pause';
 
-  const contents = <div className={styles.buttonContainer}>
-    <div className={classNames(styles.left, {
-      [styles.paused]: paused,
-    })} />
-    <div className={classNames(styles.right, {
-      [styles.paused]: paused,
-    })} />
-    <SrOnly>{label}</SrOnly>
-  </div>;
+  const contents = (
+    <div className={styles.buttonContainer}>
+      <div
+        className={classNames(styles.left, {
+          [styles.paused]: paused,
+        })}
+      />
+      <div
+        className={classNames(styles.right, {
+          [styles.paused]: paused,
+        })}
+      />
+      <SrOnly>{label}</SrOnly>
+    </div>
+  );
 
   // Use a <button> if we are interactive, else nothing
   if (togglePlayPause) {
     return (
-      <button
-        className={styles.playPauseButton}
-        onClick={togglePlayPause}
-      >
+      <button className={styles.playPauseButton} onClick={togglePlayPause}>
         {contents}
       </button>
     );

--- a/src/components/Player/components/PlayPauseButton.scss
+++ b/src/components/Player/components/PlayPauseButton.scss
@@ -8,6 +8,10 @@ $animation-effect: 0.3s ease;
   border: none;
   cursor: pointer;
   background: transparent;
+
+  &:focus {
+    outline-color: white;
+  }
 }
 
 .buttonContainer {

--- a/src/components/Player/components/PlayPauseButton.scss
+++ b/src/components/Player/components/PlayPauseButton.scss
@@ -22,11 +22,9 @@ $animation-effect: 0.3s ease;
   justify-content: space-between;
   position: relative;
 
-
   padding: 0;
   width: $button-length;
   height: $button-length;
-
 }
 
 .left {

--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { withRouter } from 'react-router-dom';
+import moment from 'moment';
 
 import { getNormalizedDateString } from 'utils/dateUtils';
 import { selectPost, selectPostLoading, selectPostError } from './selectors';
@@ -24,6 +25,7 @@ export class Post extends React.Component {
     }
     const { episodes } = this.props.post;
     const time = getNormalizedDateString(this.props.post.publishAt);
+    const machineReadableTime = moment(this.props.post.publishAt).toISOString();
 
     let categories;
     if (this.props.post.categories && this.props.post.categories.length > 0) {
@@ -43,11 +45,13 @@ export class Post extends React.Component {
     }
 
     return (
-      <div className={styles.post}>
+      <article className={styles.post}>
         <h1 className={styles.title}>{this.props.post.title}</h1>
         <div className={styles.meta}>
           {categories}
-          <div className={styles.createdAt}>{time}</div>
+          <time className={styles.createdAt} dateTime={machineReadableTime}>
+            {time}
+          </time>
         </div>
         <p
           className={styles.body}
@@ -61,7 +65,7 @@ export class Post extends React.Component {
               playOnDemand={this.props.playOnDemand}
             />
           ))}
-      </div>
+      </article>
     );
   }
 }

--- a/src/components/PostPreview/index.js
+++ b/src/components/PostPreview/index.js
@@ -21,18 +21,15 @@ const PostPreview = props => {
   }
 
   return (
-    <div className={styles.postPreview}>
-      <ImageLink
-        images={props.croppedImages}
-        link={`/post/${props.slug}`}
-        imageDescription={props.title}
-      >
-        {categories}
-      </ImageLink>
-      <Link className={styles.titleLink} to={`/post/${props.slug}`}>
-        <h2 className={styles.title}>{props.title}</h2>
-      </Link>
-    </div>
+    <ImageLink
+      images={props.croppedImages}
+      link={`/post/${props.slug}`}
+      imageDescription=""
+      className={styles.link}
+    >
+      {categories}
+      <h2 className={styles.title}>{props.title}</h2>
+    </ImageLink>
   );
 };
 

--- a/src/components/PostPreview/styles.scss
+++ b/src/components/PostPreview/styles.scss
@@ -11,13 +11,14 @@
   text-align: center;
 }
 
-.titleLink {
+.link {
   color: inherit;
   text-decoration: none;
-}
+  display: block;
 
-.titleLink:hover {
-  text-decoration: underline;
+  &:hover, &:focus {
+    text-decoration: underline;
+  }
 }
 
 .createdBy {

--- a/src/components/PostPreview/styles.scss
+++ b/src/components/PostPreview/styles.scss
@@ -16,7 +16,8 @@
   text-decoration: none;
   display: block;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 }

--- a/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
+++ b/src/components/PostPreview/tests/__snapshots__/index.test.js.snap
@@ -1,76 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PostPreview /> renders correctly with categories 1`] = `
-<div
-  className="postPreview"
->
-  <ImageLink
-    imageDescription="title"
-    images={
-      Object {
-        "large": "large_image",
-        "medium": "medium_image",
-        "small": "small_image",
-      }
+<ImageLink
+  className="link"
+  imageDescription=""
+  imageProps={Object {}}
+  images={
+    Object {
+      "large": "large_image",
+      "medium": "medium_image",
+      "small": "small_image",
     }
-    link="/post/slug"
+  }
+  link="/post/slug"
+>
+  <CategoryTag
+    backgroundColor="#FFFFFF"
+    index={0}
+    key="0"
+    name="categoryName1"
+    position="bottom"
+    textColor="#000000"
+  />
+  <CategoryTag
+    backgroundColor="#FFFFFF"
+    index={1}
+    key="1"
+    name="categoryName1"
+    position="bottom"
+    textColor="#000000"
+  />
+  <h2
+    className="title"
   >
-    <CategoryTag
-      backgroundColor="#FFFFFF"
-      index={0}
-      key="0"
-      name="categoryName1"
-      position="bottom"
-      textColor="#000000"
-    />
-    <CategoryTag
-      backgroundColor="#FFFFFF"
-      index={1}
-      key="1"
-      name="categoryName1"
-      position="bottom"
-      textColor="#000000"
-    />
-  </ImageLink>
-  <Link
-    className="titleLink"
-    replace={false}
-    to="/post/slug"
-  >
-    <h2
-      className="title"
-    >
-      title
-    </h2>
-  </Link>
-</div>
+    title
+  </h2>
+</ImageLink>
 `;
 
 exports[`<PostPreview /> renders correctly without categories 1`] = `
-<div
-  className="postPreview"
->
-  <ImageLink
-    imageDescription="title"
-    images={
-      Object {
-        "large": "large_image",
-        "medium": "medium_image",
-        "small": "small_image",
-      }
+<ImageLink
+  className="link"
+  imageDescription=""
+  imageProps={Object {}}
+  images={
+    Object {
+      "large": "large_image",
+      "medium": "medium_image",
+      "small": "small_image",
     }
-    link="/post/slug"
-  />
-  <Link
-    className="titleLink"
-    replace={false}
-    to="/post/slug"
+  }
+  link="/post/slug"
+>
+  <h2
+    className="title"
   >
-    <h2
-      className="title"
-    >
-      title
-    </h2>
-  </Link>
-</div>
+    title
+  </h2>
+</ImageLink>
 `;

--- a/src/components/Shows/ShowPreview/index.js
+++ b/src/components/Shows/ShowPreview/index.js
@@ -21,11 +21,7 @@ const ShowPreview = props => {
         <Link className={styles.link} to={`/programmer/${props.slug}`}>
           <div className={styles.imageWrapper}>
             <LazyLoad height={300} offset={100} once>
-              <img
-                className={styles.image}
-                src={props.logoImageUrl}
-                alt=""
-              />
+              <img className={styles.image} src={props.logoImageUrl} alt="" />
             </LazyLoad>
           </div>
           <h2>{props.title}</h2>

--- a/src/components/Shows/ShowPreview/index.js
+++ b/src/components/Shows/ShowPreview/index.js
@@ -18,18 +18,16 @@ const ShowPreview = props => {
     <div className={styles.container}>
       {categories}
       <div className={styles.padding}>
-        <div className={styles.imageWrapper}>
-          <Link to={`/programmer/${props.slug}`}>
+        <Link className={styles.link} to={`/programmer/${props.slug}`}>
+          <div className={styles.imageWrapper}>
             <LazyLoad height={300} offset={100} once>
               <img
                 className={styles.image}
                 src={props.logoImageUrl}
-                alt={props.title}
+                alt=""
               />
             </LazyLoad>
-          </Link>
-        </div>
-        <Link className={styles.title} to={`/programmer/${props.slug}`}>
+          </div>
           <h2>{props.title}</h2>
         </Link>
         <div>{props.lead}</div>

--- a/src/components/Shows/ShowPreview/styles.scss
+++ b/src/components/Shows/ShowPreview/styles.scss
@@ -32,12 +32,12 @@ $image-height: $max-width - 2 * $padding;
   max-height: $image-height;
 }
 
-.title {
+.link {
   color: inherit;
   text-decoration: none;
   text-align: center;
 
-  &:hover {
+  &:hover, &:focus {
     text-decoration: underline;
   }
 }

--- a/src/components/Shows/ShowPreview/styles.scss
+++ b/src/components/Shows/ShowPreview/styles.scss
@@ -37,7 +37,8 @@ $image-height: $max-width - 2 * $padding;
   text-decoration: none;
   text-align: center;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 }

--- a/src/components/common/ImageLink/index.js
+++ b/src/components/common/ImageLink/index.js
@@ -2,22 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LazyLoad from 'react-lazyload';
 import { Link } from 'react-router-dom';
+import classNames from 'classnames';
 
 import styles from './styles.scss';
 
-const ImageLink = props => {
-  const { small, medium, large } = props.images;
+const ImageLink = ({images, link, imageDescription, children, imageProps, ...restProps}) => {
+  const { small, medium, large } = images;
+  const { className: customImageClassName, ...restImageProps} = imageProps;
   return (
-    <Link to={props.link} className={styles.nonSelectable}>
+    <Link to={link} {...restProps}>
       <LazyLoad height={350} offset={100} once>
         <img
-          className={`${styles.image} ${styles.nonSelectable}`}
+          className={classNames(styles.image, customImageClassName)}
           srcSet={`${large} 1024w, ${medium} 768w, ${small} 300w`}
           src={large}
-          alt={props.imageDescription}
+          alt={imageDescription}
+          {...restImageProps}
         />
       </LazyLoad>
-      {props.children}
+      {children}
     </Link>
   );
 };
@@ -31,6 +34,12 @@ ImageLink.propTypes = {
   link: PropTypes.string.isRequired,
   imageDescription: PropTypes.string.isRequired,
   children: PropTypes.node,
+  className: PropTypes.string,
+  imageProps: PropTypes.object,
+};
+
+ImageLink.defaultProps = {
+  imageProps: {},
 };
 
 export default ImageLink;

--- a/src/components/common/ImageLink/index.js
+++ b/src/components/common/ImageLink/index.js
@@ -6,9 +6,16 @@ import classNames from 'classnames';
 
 import styles from './styles.scss';
 
-const ImageLink = ({images, link, imageDescription, children, imageProps, ...restProps}) => {
+const ImageLink = ({
+  images,
+  link,
+  imageDescription,
+  children,
+  imageProps,
+  ...restProps
+}) => {
   const { small, medium, large } = images;
-  const { className: customImageClassName, ...restImageProps} = imageProps;
+  const { className: customImageClassName, ...restImageProps } = imageProps;
   return (
     <Link to={link} {...restProps}>
       <LazyLoad height={350} offset={100} once>

--- a/src/components/common/ImageLink/styles.scss
+++ b/src/components/common/ImageLink/styles.scss
@@ -1,7 +1,3 @@
 .image {
   width: 100%;
 }
-
-.nonSelectable {
-  user-select: none;
-}

--- a/src/components/common/ImageLink/tests/__snapshots__/index.test.js.snap
+++ b/src/components/common/ImageLink/tests/__snapshots__/index.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<ImageLink /> renders correctly 1`] = `
 <Link
-  className="nonSelectable"
   replace={false}
   to="/link/to/resource"
 >
@@ -17,7 +16,7 @@ exports[`<ImageLink /> renders correctly 1`] = `
   >
     <img
       alt=" img description"
-      className="image nonSelectable"
+      className="image"
       src="/large.jpg"
       srcSet="/large.jpg 1024w, /medium.jpg 768w, /small.jpg 300w"
     />

--- a/src/components/common/SrOnly/index.js
+++ b/src/components/common/SrOnly/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import styles from './styles.scss';
+
+/**
+ * Component whose contents are announced by screen-readers, but hidden visually.
+ */
+const SrOnly = ({ children, element, ...restProps }) => {
+  // JSX requires element names to be Capitalized
+  const ElementToUse = element;
+
+  return <ElementToUse {...restProps} className={styles.srOnly}>
+    {children}
+  </ElementToUse>
+};
+
+SrOnly.propTypes = {
+  children: PropTypes.node,
+  element: PropTypes.string,
+};
+
+SrOnly.defaultProps = {
+  element: 'div',
+};
+
+export default SrOnly;

--- a/src/components/common/SrOnly/index.js
+++ b/src/components/common/SrOnly/index.js
@@ -10,9 +10,11 @@ const SrOnly = ({ children, element, ...restProps }) => {
   // JSX requires element names to be Capitalized
   const ElementToUse = element;
 
-  return <ElementToUse {...restProps} className={styles.srOnly}>
-    {children}
-  </ElementToUse>
+  return (
+    <ElementToUse {...restProps} className={styles.srOnly}>
+      {children}
+    </ElementToUse>
+  );
 };
 
 SrOnly.propTypes = {

--- a/src/components/common/SrOnly/styles.scss
+++ b/src/components/common/SrOnly/styles.scss
@@ -1,0 +1,13 @@
+.srOnly {
+  /*
+  Combination of CSS tricks that hide the element without removing it from
+  the document structure used by screen-readers
+  */
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0 !important;
+  border: 0 !important;
+  height: 1px !important;
+  width: 1px !important;
+  overflow: hidden;
+}

--- a/src/components/common/button/SocialMediaButton/index.js
+++ b/src/components/common/button/SocialMediaButton/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styles from './styles.scss';
 
 const SocialMediaButton = props => (
-  <a target="_blank" rel="noopener noreferrer" href={props.link}>
+  <a target="_blank" rel="noopener noreferrer" href={props.link} className={styles.link}>
     <img
       src={props.image}
       alt={props.text}

--- a/src/components/common/button/SocialMediaButton/index.js
+++ b/src/components/common/button/SocialMediaButton/index.js
@@ -4,7 +4,12 @@ import PropTypes from 'prop-types';
 import styles from './styles.scss';
 
 const SocialMediaButton = props => (
-  <a target="_blank" rel="noopener noreferrer" href={props.link} className={styles.link}>
+  <a
+    target="_blank"
+    rel="noopener noreferrer"
+    href={props.link}
+    className={styles.link}
+  >
     <img
       src={props.image}
       alt={props.text}

--- a/src/components/common/button/SocialMediaButton/styles.scss
+++ b/src/components/common/button/SocialMediaButton/styles.scss
@@ -5,3 +5,12 @@
   margin-left: $social-media-button-margin;
   margin-right: $social-media-button-margin;
 }
+
+.link {
+  &:focus {
+    // Gray, since the buttons can be over light or dark background
+    outline-color: #888;
+    // Also add some brightness, since the outline is more subtle
+    filter: brightness(115%);
+  }
+}

--- a/src/components/common/button/SocialMediaButton/tests/__snapshots__/index.test.js.snap
+++ b/src/components/common/button/SocialMediaButton/tests/__snapshots__/index.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<SocialMediaButton /> renders correctly 1`] = `
 <a
+  className="link"
   href="link"
   rel="noopener noreferrer"
   target="_blank"


### PR DESCRIPTION
* Use [interactive HTML elements][interactive-html] (`<a>`, `<button>`) for interactive elements
* Use [semantic HTML elements][semantic-html] instead of generic `<div>`
* [Do not duplicate information for screen readers][alt-text], by leaving out `alt`
  text when `alt` text is the same as the text immediately after
* Do not duplicate links, instead use one link per destination
* Ensure the outline can be seen in all browsers by styling it
  manually, taking into account the contrast
* Add label for the screen reader to the play/pause button, implementing a utility for screen-reader labels
* Some extra linting

[interactive-html]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Accessibility_concerns
[semantic-html]: https://developer.mozilla.org/en-US/docs/Glossary/Semantics#Semantics_in_HTML
[alt-text]: https://webaim.org/techniques/alttext/#intro