### PR TITLE
fixed minor flexbox problem in episode

### DIFF
--- a/src/components/Player/components/PlayPauseButton.scss
+++ b/src/components/Player/components/PlayPauseButton.scss
@@ -21,7 +21,7 @@ $animation-effect: 0.3s ease;
   flex-direction: row;
   justify-content: space-between;
   position: relative;
-
+  flex-shrink: 0;
   padding: 0;
   width: $button-length;
   height: $button-length;


### PR DESCRIPTION
lead-teksten i episode havnet for langt til venstre og blendet sammen med playbutton, etter published at blei lagt til i episode komponenten. Fant ikke hvor feilen lå, men fikset den med med flex shrink