### PR TITLE
fix: add try/catch block when fetching current show

### DIFF
--- a/src/components/Player/sagas.js
+++ b/src/components/Player/sagas.js
@@ -133,7 +133,6 @@ function* playLiveSaga() {
 function* updateLiveTitle() {
   try {
     const currentShow = yield call(getCurrentShows);
-    console.log(currentShow);
     const liveTitle = currentShow.current.title;
     yield put(currentShowTitle(liveTitle));
   } catch (e) {

--- a/src/components/Player/sagas.js
+++ b/src/components/Player/sagas.js
@@ -131,9 +131,14 @@ function* playLiveSaga() {
 }
 
 function* updateLiveTitle() {
-  const currentShow = yield call(getCurrentShows);
-  const liveTitle = currentShow.current.title;
-  yield put(currentShowTitle(liveTitle));
+  try {
+    const currentShow = yield call(getCurrentShows);
+    console.log(currentShow);
+    const liveTitle = currentShow.current.title;
+    yield put(currentShowTitle(liveTitle));
+  } catch (e) {
+    console.error('Could not load current show.', e);
+  }
 }
 
 function* updateLiveTitleTimer() {


### PR DESCRIPTION
Fixes the bug problem where the player can't play/pause when `https://api.radiorevolt.no/v2/sendinger/currentshows` is unavailable. This is a separate API to `kapina-backend`, and is only used to fetch information about what's currently playing. The API being unavailable does not have a large impact on the site, and should therefore not have a noticeable impact on the sites functions.