### PR TITLE
change width of post in frontend

### DIFF
--- a/src/components/Footer/tests/__snapshots__/index.test.js.snap
+++ b/src/components/Footer/tests/__snapshots__/index.test.js.snap
@@ -60,7 +60,7 @@ exports[`<Footer /> renders correctly 1`] = `
       Personvern
     </Link>
     <p>
-      2019
+      2020
        © Radio Revolt
     </p>
   </div>
@@ -127,7 +127,7 @@ exports[`<Footer /> renders correctly on error 1`] = `
       Personvern
     </Link>
     <p>
-      2019
+      2020
        © Radio Revolt
     </p>
   </div>
@@ -194,7 +194,7 @@ exports[`<Footer /> renders correctly while loading 1`] = `
       Personvern
     </Link>
     <p>
-      2019
+      2020
        © Radio Revolt
     </p>
   </div>

--- a/src/components/Post/styles.scss
+++ b/src/components/Post/styles.scss
@@ -2,7 +2,7 @@
 
 .post {
   margin: 0 auto;
-  max-width: 700px;
+  max-width: 800px;
 }
 
 .title {

--- a/src/components/Post/styles.scss
+++ b/src/components/Post/styles.scss
@@ -2,6 +2,7 @@
 
 .post {
   margin: 0 auto;
+  max-width: 700px;
 }
 
 .title {


### PR DESCRIPTION
Changed the width of the articles from 1000px to 700px. 
Should it be smaller, wider or is it good now?
The page becomes a bit empty, but hopefully the text becomes more readable. 
It is more space between the text and the SoMe buttons. Is that alright or should we try to move the buttons closer to the text?

Used px instead of % so we don't get all the whitespace on smaller screens where the width already is small enough. 

 